### PR TITLE
Better image(s) field + safeguard for github triggered builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,16 +109,16 @@ module.exports.createSlackMessage = async (build, githubCommit) => {
   };
 
   // Add source information to the message.
-  const source = build.source || null;
-  if (source) {
+  const { repoSource } = build.source || null;
+  if (repoSource) {
     message.attachments[0].fields.push({
       title: 'Repository',
-      value: build.source.repoSource.repoName,
+      value: repoSource.repoName,
     });
 
     message.attachments[0].fields.push({
       title: 'Branch',
-      value: build.source.repoSource.branchName,
+      value: repoSource.branchName,
     });
 
     if (githubCommit) {
@@ -129,13 +129,17 @@ module.exports.createSlackMessage = async (build, githubCommit) => {
     }
   }
 
-  // Add images to the message.
+  // Add image(s) to the message.
   const images = build.images || [];
-  // eslint-disable-next-line no-plusplus
-  for (let i = 0, len = images.length; i < len; i++) {
+  if (images.length === 1) {
     message.attachments[0].fields.push({
       title: 'Image',
-      value: images[i],
+      value: images[0],
+    });
+  } else if (images.length > 1) {
+    message.attachments[0].fields.push({
+      title: 'Images',
+      value: images.join('\n'),
     });
   }
   return message;

--- a/index.js
+++ b/index.js
@@ -131,14 +131,9 @@ module.exports.createSlackMessage = async (build, githubCommit) => {
 
   // Add image(s) to the message.
   const images = build.images || [];
-  if (images.length === 1) {
+  if (images.length) {
     message.attachments[0].fields.push({
-      title: 'Image',
-      value: images[0],
-    });
-  } else if (images.length > 1) {
-    message.attachments[0].fields.push({
-      title: 'Images',
+      title: `Image${(images.length > 1) ? 's' : ''}`,
       value: images.join('\n'),
     });
   }

--- a/package.json
+++ b/package.json
@@ -14,16 +14,16 @@
     "url": "git+https://github.com/Philmod/google-cloud-build-slack.git"
   },
   "dependencies": {
-    "@octokit/rest": "^16.20.0",
-    "@slack/client": "5.0.0",
+    "@octokit/rest": "^16.27.3",
+    "@slack/client": "5.0.1",
     "humanize-duration": "3.18.0"
   },
   "devDependencies": {
-    "async": "^2.6.2",
-    "mocha": "6.1.1",
-    "nyc": "^13.3.0",
+    "async": "^3.0.1",
+    "mocha": "6.1.4",
+    "nyc": "^14.1.1",
     "should": "13.2.3",
-    "sinon": "^7.3.0",
+    "sinon": "^7.3.2",
     "serverless-google-cloudfunctions": "^2.3.2"
   },
   "author": "Philmod <philippe.modard@gmail.com>",

--- a/test.js
+++ b/test.js
@@ -26,7 +26,6 @@ describe('createSlackMessage', () => {
       finishTime: '2017-03-19T00:08:12.220502Z',
       source: {},
     };
-    // const build = lib.eventToBuild(base64Build);
     const message = await lib.createSlackMessage(build);
 
     message.text.should.equal(`Build \`${build.id}\` finished`);

--- a/test.js
+++ b/test.js
@@ -24,10 +24,12 @@ describe('createSlackMessage', () => {
       logUrl: 'https://logurl.com',
       status: 'SUCCESS',
       finishTime: '2017-03-19T00:08:12.220502Z',
+      source: {},
     };
+    // const build = lib.eventToBuild(base64Build);
     const message = await lib.createSlackMessage(build);
 
-    message.text.should.equal('Build `build-id` finished');
+    message.text.should.equal(`Build \`${build.id}\` finished`);
     should.exist(message.attachments);
     message.attachments.should.have.length(1);
     const attachment = message.attachments[0];
@@ -44,6 +46,7 @@ describe('createSlackMessage', () => {
       status: 'WORKING',
       startTime: '2017-03-19T00:08:12.220502Z',
       finishTime: null,
+      source: {},
     };
 
     const message = await lib.createSlackMessage(build);
@@ -67,6 +70,7 @@ describe('createSlackMessage', () => {
       status: 'SUCCESS',
       startTime: new Date(now - deltaInMinutes * MS_PER_MINUTE),
       finishTime: now,
+      source: {},
     };
     const message = await lib.createSlackMessage(build);
 
@@ -83,6 +87,7 @@ describe('createSlackMessage', () => {
       status: 'WORKING',
       startTime: new Date(now - deltaInMinutes * MS_PER_MINUTE),
       finishTime: null,
+      source: {},
     };
     const message = await lib.createSlackMessage(build);
 
@@ -97,13 +102,13 @@ describe('createSlackMessage', () => {
       status: 'SUCCESS',
       finishTime: Date.now(),
       images: ['image-1', 'image-2'],
+      source: {},
     };
     const message = await lib.createSlackMessage(build);
 
     const attachment = message.attachments[0];
-    attachment.fields.should.have.length(nbCommonFields + build.images.length);
-    attachment.fields[nbCommonFields].value.should.equal('image-1');
-    attachment.fields[nbCommonFields + 1].value.should.equal('image-2');
+    attachment.fields.should.have.length(nbCommonFields + 1);
+    attachment.fields[nbCommonFields].value.should.equal('image-1\nimage-2');
   });
 
   it('should include the source info in the message', async () => {


### PR DESCRIPTION
Hello,

This PR provideds a better image(s) field. That's to say for builds with >1 images the field has name `Images` with 1 value of newline delimited images rather than `Image` and a value per image. 

Before:
```
Image
gcr.io/my-project/my-image-1
Image
gcr.io/my-project/my-image-2
```

After:
```
Images
gcr.io/my-project/my-image-1
gcr.io/my-project/my-image-2
```

Secondly it adds a safeguard for github app triggered builds that do not contain a `build.source.repoSource` object.

Before:
`Error: TypeError: Cannot read property 'repoName' of undefined`
After:
```
Build `1eo8ujfdnbb-83d0-4sjc-8ejd9-329fjfn203` started
Build logs
Status
WORKING
Google Cloud BuildToday at 1:01 PM
```

Finally I've also taken the liberty to update packages.